### PR TITLE
Improve data caching on risk-data service

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,7 @@ async function createServer () {
   })
 
   const CACHE_EXPIRY = 600 // 10 minutes
-  const CACHE_STALE = 30 // 8 minutes
+  const CACHE_STALE = 460 // 8 minutes
   const CACHE_GENERATE_TIMEOUT = 20 // 20 seconds
 
   // Register the plugins

--- a/server/index.js
+++ b/server/index.js
@@ -7,9 +7,9 @@ import logErrors from './plugins/log-errors.js'
 import logging from './plugins/logging.js'
 import dataRefresh from './plugins/dataRefresh.js'
 import blipp from 'blipp'
-import { S3Client, HeadObjectCommand } from '@aws-sdk/client-s3'
 
 async function createServer () {
+  // Create the hapi server
   const server = Hapi.server({
     host: dataConfig.host,
     port: dataConfig.port,
@@ -24,33 +24,18 @@ async function createServer () {
   })
 
   const CACHE_EXPIRY = 600 // 10 minutes
-  const CACHE_STALE = 480 // 8 minutes
+  const CACHE_STALE = 30 // 8 minutes
   const CACHE_GENERATE_TIMEOUT = 20 // 20 seconds
 
+  // Register the plugins
   await server.register(router)
   await server.register(logErrors)
   await server.register(logging)
   await server.register({ plugin: dataRefresh, options: { time: CACHE_STALE * 1000 } })
   await server.register(blipp)
 
-  const manifestKey = `${dataConfig.holdingCommentsPrefix}/${dataConfig.manifestFilename}`
-  const client = new S3Client({ region: dataConfig.awsBucketRegion })
-  let lastModified = null
-
-  server.method('getExtraInfoData', async () => {
-    const params = { Bucket: dataConfig.awsBucketName, Key: manifestKey }
-    const command = new HeadObjectCommand(params)
-    const response = await client.send(command)
-
-    if (JSON.stringify(response.LastModified) !== JSON.stringify(lastModified)) {
-      lastModified = response.LastModified
-      console.log('Manifest file has been modified since the last check.')
-      return await getExtraInfoData()
-    } else {
-      console.log('Manifest file has not been modified since the last check.')
-      return null
-    }
-  }, {
+  // Register server methods
+  server.method('getExtraInfoData', getExtraInfoData, {
     cache: {
       cache: 'server_cache',
       expiresIn: CACHE_EXPIRY * 1000,

--- a/server/services/__tests__/s3dataLoader.spec.js
+++ b/server/services/__tests__/s3dataLoader.spec.js
@@ -30,9 +30,7 @@ describe('s3dataLoader', () => {
   })
 
   test('should save and return the data if manifest file has been modified', async () => {
-    const mockLastModified = '2023-10-02T00:00:00.000Z' // New last modified date
-    const mockCachedModified = '2023-10-01T00:00:00.000Z' // Cached last modified date
-    const mockCachedData = { key: 'oldValue' }
+    const mockLastModified = '2023-10-02T00:00:00.000Z'
     const mockNewData = [{ key: 'newValue' }]
     s3Mock.on(HeadObjectCommand).resolves({ LastModified: new Date(mockLastModified) })
 
@@ -42,11 +40,6 @@ describe('s3dataLoader', () => {
           return JSON.stringify(mockNewData)
         })
       }
-    })
-
-    getCache.mockImplementation((key) => {
-      if (key === 'lastModified') return mockCachedModified
-      if (key === 'data') return mockCachedData
     })
 
     const data = await s3DataLoader()

--- a/server/services/__tests__/s3dataLoader.spec.js
+++ b/server/services/__tests__/s3dataLoader.spec.js
@@ -20,8 +20,11 @@ describe('s3dataLoader', () => {
     s3Mock.on(GetObjectCommand).resolves({ Body: mockCachedData })
 
     getCache.mockImplementation((key) => {
-      if (key === 'lastModified') return mockLastModified
-      if (key === 'data') return mockCachedData
+      if (key === 'lastModified') {
+        return mockLastModified
+      } else {
+        return mockCachedData
+      }
     })
 
     const data = await s3DataLoader()

--- a/server/services/__tests__/s3dataLoader.spec.js
+++ b/server/services/__tests__/s3dataLoader.spec.js
@@ -5,10 +5,6 @@ import { getCache } from '../serverCache.js'
 
 jest.mock('../../config.js')
 jest.mock('../serverCache.js')
-jest.mock('../s3dataLoader.js', () => ({
-  ...jest.requireActual('../s3dataLoader.js'),
-  transformToString: jest.fn()
-}))
 const s3Mock = mockClient(S3Client)
 
 describe('s3dataLoader', () => {
@@ -28,11 +24,29 @@ describe('s3dataLoader', () => {
       if (key === 'data') return mockCachedData
     })
 
-    const { transformToString } = require('../s3dataLoader.js')
-    transformToString.mockResolvedValue(JSON.stringify(mockCachedData))
-
     const data = await s3DataLoader()
 
     expect(data).toEqual(mockCachedData)
+  })
+
+  it.only('should save and return the data if manifest file has been modified', async () => {
+    const mockLastModified = '2023-10-02T00:00:00.000Z' // New last modified date
+    const mockCachedModified = '2023-10-01T00:00:00.000Z' // Cached last modified date
+    const mockCachedData = { key: 'oldValue' }
+    const mockNewData = { key: 'newValue' }
+    s3Mock.on(HeadObjectCommand).resolves({ LastModified: new Date(mockLastModified) })
+
+    s3Mock.on(GetObjectCommand).resolves({ Body: { transformToString: jest.fn(() => {
+      return JSON.stringify(mockNewData)
+    }) } })
+
+    getCache.mockImplementation((key) => {
+      if (key === 'lastModified') return mockCachedModified
+      if (key === 'data') return mockCachedData
+    })
+
+    const data = await s3DataLoader()
+
+    expect(data).toEqual(mockNewData)
   })
 })

--- a/server/services/s3dataLoader.js
+++ b/server/services/s3dataLoader.js
@@ -33,13 +33,15 @@ const s3DataLoader = async () => {
   
   if (JSON.stringify(manifestFile.LastModified) === JSON.stringify(lastModified)) {
     console.log('Manifest file has not been modified since the last check.')
-    return lastModified
+    const cachedData = getCache('data')
+    return cachedData
   } else {
-    setCache('lastModified', manifestFile.LastModified)
     console.log('Manifest file has been modified since the last check.')
     const response = await doS3Command(manifestKey)
     const contents = await response.Body.transformToString()
     const data = await loadFeatureData(JSON.parse(contents))
+    setCache('lastModified', manifestFile.LastModified)
+    setCache('data', data)
     
     return data
   }

--- a/server/services/s3dataLoader.js
+++ b/server/services/s3dataLoader.js
@@ -1,5 +1,6 @@
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
+import { S3Client, GetObjectCommand,HeadObjectCommand } from '@aws-sdk/client-s3'
 import { dataConfig } from '../config.js'
+import { setCache, getCache } from './serverCache.js'
 
 const s3DataLoader = async () => {
   const manifestKey = `${dataConfig.holdingCommentsPrefix}/${dataConfig.manifestFilename}`
@@ -25,11 +26,23 @@ const s3DataLoader = async () => {
     return jsonData
   }
 
-  const response = await doS3Command(manifestKey)
-  const contents = await response.Body.transformToString()
-  const data = await loadFeatureData(JSON.parse(contents))
-
-  return data
+  const params = { Bucket: dataConfig.awsBucketName, Key: manifestKey }
+  const getHeadCommand = new HeadObjectCommand(params)
+  const manifestFile = await client.send(getHeadCommand)
+  const lastModified = getCache('lastModified')
+  
+  if (JSON.stringify(manifestFile.LastModified) === JSON.stringify(lastModified)) {
+    console.log('Manifest file has not been modified since the last check.')
+    return lastModified
+  } else {
+    setCache('lastModified', manifestFile.LastModified)
+    console.log('Manifest file has been modified since the last check.')
+    const response = await doS3Command(manifestKey)
+    const contents = await response.Body.transformToString()
+    const data = await loadFeatureData(JSON.parse(contents))
+    
+    return data
+  }
 }
 
 export default s3DataLoader

--- a/server/services/serverCache.js
+++ b/server/services/serverCache.js
@@ -1,0 +1,11 @@
+let cache = {}
+
+const setCache = (key, value) => {
+  cache[key] = value
+}
+
+const getCache = (key) => {
+  return cache[key]
+}
+
+export { setCache, getCache }

--- a/server/services/serverCache.js
+++ b/server/services/serverCache.js
@@ -1,4 +1,4 @@
-let cache = {}
+const cache = {}
 
 const setCache = (key, value) => {
   cache[key] = value


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1589

The risk-data service currently pulls all data from the s3 bucket every 8 minutes.

This could be improved by checking last modified times in the index file, and checking each files last modified time.