### PR TITLE
Update cyltfr-data to Node V22 (Update README)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -23,7 +23,7 @@ This repository is part of the CYLTFR service which also includes:\
 <https://github.com/DEFRA/cyltfr-admin>
 
 ## Prerequisites
-Node v20.x/
+Node v22.x/
 Docker v20.10.0+
 
 ### Start app


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1830

This change updated the README file as this was previously missed.